### PR TITLE
added Parallel function for running multiple functions in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ run multiple functions in parallel:
 ```go
 func UploadAndDownload() error {
   var email string
-  errs := async.Parallel(
+  errs := bigopool.Parallel(
     func() error {
       return api.Post(Request{Email: "bob@gmail.com"})
     },

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ results, errs := dispatcher.Wait()
 
 ## Parallel
 
+run multiple functions in parallel:
 ```go
 func UploadAndDownload() error {
   var email string

--- a/README.md
+++ b/README.md
@@ -33,10 +33,36 @@ dispatcher.Enqueue(TestJob{}) // <-- add one job
 dispatcher.Enqueue(TestJob{}, TestJob{}) // <-- add multiple jobs
 
 // wait for workers to finish (this is a blocking call)
-results, errs := dispatcher.Wait() 
+results, errs := dispatcher.Wait()
 ```
 
 :boom:
+
+## Parallel
+
+```go
+func UploadAndDownload() error {
+  var email string
+  errs := async.Parallel(
+    func() error {
+      return api.Post(Request{Email: "bob@gmail.com"})
+    },
+
+    func() error {
+      user, err := api.Get(Request{ID: 1234})
+      if err != nil {
+        return err
+      }
+
+      email = user.Email
+      return nil
+    },
+  )
+
+  fmt.Println("email:", email)
+  return errs.ToError()
+}
+```
 
 ## Motivation
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,57 @@
+package bigopool
+
+import (
+	"fmt"
+	"sync"
+)
+
+type (
+	// Errors is an interface for accessing a slice of errors.
+	Errors interface {
+		All() []error
+		ToError() error
+		IsEmpty() bool
+	}
+
+	// errs is a thread safe struct for appending a slice of errors.
+	errs struct {
+		mutex sync.Mutex
+		all   []error
+	}
+)
+
+// All returns the underlyings slice of errors.
+func (ee *errs) All() []error {
+	return ee.all
+}
+
+// ToError returns all errors as a single error.
+func (ee *errs) ToError() error {
+	if ee.IsEmpty() {
+		return nil
+	}
+
+	return ee
+}
+
+// IsEmpty is true if there are no errors.
+func (ee *errs) IsEmpty() bool {
+	return len(ee.all) == 0
+}
+
+// Error implements the error interface.
+func (ee *errs) Error() string {
+	errorStr := ""
+	for _, err := range ee.All() {
+		errorStr = fmt.Sprintf("%s\n%s", errorStr, err.Error())
+	}
+
+	return errorStr
+}
+
+// append safely appends to the error slice.
+func (ee *errs) append(err error) {
+	ee.mutex.Lock()
+	ee.all = append(ee.all, err)
+	ee.mutex.Unlock()
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,35 @@
+package async
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAll(t *testing.T) {
+	ee := errs{}
+	assert.Empty(t, ee.All())
+
+	ee.append(errors.New("error 1"))
+	ee.append(errors.New("error 2"))
+	assert.Equal(t, 2, len(ee.All()))
+}
+
+func TestToError(t *testing.T) {
+	ee := errs{}
+	assert.Nil(t, ee.ToError())
+
+	ee.append(errors.New("error 1"))
+	ee.append(errors.New("error 2"))
+	assert.NotNil(t, ee.ToError())
+}
+
+func TestIsEmpty(t *testing.T) {
+	ee := errs{}
+	assert.True(t, ee.IsEmpty())
+
+	ee.append(errors.New("error 1"))
+	ee.append(errors.New("error 2"))
+	assert.False(t, ee.IsEmpty())
+}

--- a/parallel.go
+++ b/parallel.go
@@ -1,0 +1,29 @@
+package bigopool
+
+import (
+	"sync"
+)
+
+// Parallel runs multiple functions in parallel and collects the errors safely.
+func Parallel(ff ...func() error) Errors {
+	var wg sync.WaitGroup
+	var ee errs
+
+	wg.Add(len(ff))
+
+	for i := range ff {
+		f := ff[i]
+
+		go func() {
+			defer wg.Done()
+
+			if err := f(); err != nil {
+				ee.append(err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	return &ee
+}

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -1,0 +1,60 @@
+package async
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParallel(t *testing.T) {
+	// Test no errors.
+	x := 0
+	m := sync.Mutex{}
+	ee := Parallel(
+		func() error {
+			m.Lock()
+			defer m.Unlock()
+			x++
+			return nil
+		},
+
+		func() error {
+			m.Lock()
+			defer m.Unlock()
+			x += 2
+			return nil
+		},
+
+		func() error {
+			m.Lock()
+			defer m.Unlock()
+			x += 3
+			return nil
+		},
+	)
+	assert.True(t, ee.IsEmpty())
+	assert.Equal(t, 6, x)
+
+	// Test witb errors.
+	y := 0
+	ee = Parallel(
+		func() error {
+			return errors.New("error 1")
+		},
+
+		func() error {
+			return errors.New("error 2")
+		},
+
+		func() error {
+			y--
+			return errors.New("error 3")
+		},
+	)
+	assert.False(t, ee.IsEmpty())
+	assert.Equal(t, 3, len(ee.All()))
+	assert.NotNil(t, ee.ToError())
+	assert.Equal(t, -1, y)
+}


### PR DESCRIPTION
- the biggest use case for this is when making multiple network calls in parallel, rather than having to setup a `sync.Waitgroup`, safely collect the errors, and call `wg.Done()` in multiple places, all you'll have to do is now call `bigopool.Parallel()`