### PR TITLE
Add CancelableParallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `bigopool` is a small library that implements high performance worker pool in Golang and allows `error`/`result` handling in the main thread.
 
-It also provides a thread safe paralell processing abstraction 
+It also provides a thread safe parallel processing abstraction
 
 ## Quickstart
 
@@ -48,7 +48,7 @@ results, errs := dispatcher.Wait()
 
 ### Parallel processing
 
-Use this if you don't need worker pools and just want to execute tasks in parelell
+Use this if you don't need worker pools and just want to execute tasks in parallel
 
 run multiple functions in parallel:
 ```go

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -96,12 +96,13 @@ func TestCancelableParallelWithError(t *testing.T) {
 			return errors.New("test")
 		},
 		func(c context.Context) error {
-			time.Sleep(100 * time.Millisecond)
+			// Set a timeout in case the context isn't canceled.
+			timer := time.NewTimer(100 * time.Millisecond)
 
 			select {
 			case <-c.Done():
 				return nil
-			default:
+			case <-timer.C:
 				// Can't t.Fatal since we aren't in the main goroutine
 				t.Log("Did not cancel context due to previous error")
 				t.Fail()

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -1,15 +1,16 @@
 package bigopool
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParallel(t *testing.T) {
-	// Test no errors.
+func TestParallelNoErrors(t *testing.T) {
 	x := 0
 	m := sync.Mutex{}
 	ee := Parallel(
@@ -36,10 +37,11 @@ func TestParallel(t *testing.T) {
 	)
 	assert.True(t, ee.IsEmpty())
 	assert.Equal(t, 6, x)
+}
 
-	// Test witb errors.
+func TestParallelWithErrors(t *testing.T) {
 	y := 0
-	ee = Parallel(
+	ee := Parallel(
 		func() error {
 			return errors.New("error 1")
 		},
@@ -57,4 +59,56 @@ func TestParallel(t *testing.T) {
 	assert.Equal(t, 3, len(ee.All()))
 	assert.NotNil(t, ee.ToError())
 	assert.Equal(t, -1, y)
+}
+
+func TestCancelableParallelNoErrors(t *testing.T) {
+	x := 0
+	m := sync.Mutex{}
+	ee := CancelableParallel(context.Background(),
+		func(context.Context) error {
+			m.Lock()
+			defer m.Unlock()
+			x++
+			return nil
+		},
+
+		func(context.Context) error {
+			m.Lock()
+			defer m.Unlock()
+			x += 2
+			return nil
+		},
+
+		func(context.Context) error {
+			m.Lock()
+			defer m.Unlock()
+			x += 3
+			return nil
+		},
+	)
+	assert.True(t, ee.IsEmpty())
+	assert.Equal(t, 6, x)
+}
+
+func TestCancelableParallelWithError(t *testing.T) {
+	ee := CancelableParallel(context.Background(),
+		func(c context.Context) error {
+			return errors.New("test")
+		},
+		func(c context.Context) error {
+			time.Sleep(100 * time.Millisecond)
+
+			select {
+			case <-c.Done():
+				return nil
+			default:
+				// Can't t.Fatal since we aren't in the main goroutine
+				t.Log("Did not cancel context due to previous error")
+				t.Fail()
+				return nil
+			}
+		},
+	)
+	assert.False(t, ee.IsEmpty())
+	assert.Len(t, ee.All(), 1)
 }


### PR DESCRIPTION
CancelableParallel is similar to Parallel, except it passes a context.Context to the worker functions, and cancels the context as soon as a worker function returns with an error.
