### PR TITLE
wrap errors so that caller's can unwrap the error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,9 +1,8 @@
 package bigopool
 
 import (
+	"fmt"
 	"sync"
-
-	"go.uber.org/multierr"
 )
 
 type (
@@ -17,41 +16,46 @@ type (
 	// errs is a thread safe struct for appending a slice of errors.
 	errs struct {
 		mutex sync.Mutex
-		errs  error
+		errs  []error
 	}
 )
 
 // All returns the underlyings slice of errors.
 func (ee *errs) All() []error {
-	return multierr.Errors(ee.errs)
+	return ee.errs
 }
 
 // ToError returns all errors as a single error.
 func (ee *errs) ToError() error {
-	if ee.errs == nil {
+	if len(ee.errs) == 0 {
 		return nil
 	}
 
-	return ee.errs
+	err := ee.errs[0]
+	for _, otherErr := range ee.errs[1:] {
+		err = fmt.Errorf("%v; %w", err, otherErr)
+	}
+
+	return err
 }
 
 // IsEmpty is true if there are no errors.
 func (ee *errs) IsEmpty() bool {
-	return len(ee.All()) == 0
+	return len(ee.errs) == 0
 }
 
 // Error implements the error interface.
 func (ee *errs) Error() string {
-	if ee.errs == nil {
+	if len(ee.errs) == 0 {
 		return ""
 	}
 
-	return ee.errs.Error()
+	return ee.ToError().Error()
 }
 
 // append safely appends to the error slice.
 func (ee *errs) append(err error) {
 	ee.mutex.Lock()
-	ee.errs = multierr.Append(ee.errs, err)
+	ee.errs = append(ee.errs, err)
 	ee.mutex.Unlock()
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -37,6 +37,8 @@ func TestIsEmpty(t *testing.T) {
 func TestError(t *testing.T) {
 	ee := errs{}
 
+	assert.Equal(t, "", ee.Error())
+
 	ee.append(errors.New("one"))
 
 	assert.Equal(t, "one", ee.Error())

--- a/errors_test.go
+++ b/errors_test.go
@@ -37,11 +37,26 @@ func TestIsEmpty(t *testing.T) {
 func TestError(t *testing.T) {
 	ee := errs{}
 
-	ee.append(errors.New("ok"))
+	ee.append(errors.New("one"))
 
-	assert.Equal(t, "\nok", ee.Error())
+	assert.Equal(t, "one", ee.Error())
 
 	ee.append(errors.New("two"))
 
-	assert.Equal(t, "\nok\ntwo", ee.Error())
+	assert.Equal(t, "one; two", ee.Error())
+}
+
+func TestUnwrapping(t *testing.T) {
+	notFoundErr := errors.New("not found")
+	badRequestErr := errors.New("bad request")
+
+	ee := errs{}
+
+	ee.append(notFoundErr)
+
+	assert.True(t, errors.Is(ee.ToError(), notFoundErr))
+	assert.False(t, errors.Is(ee.ToError(), badRequestErr))
+
+	ee.append(badRequestErr)
+	assert.True(t, errors.Is(ee.ToError(), badRequestErr))
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/bigodines/bigopool
 go 1.15
 
 require (
-	github.com/stretchr/testify v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/stretchr/testify v1.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/bigodines/bigopool
+
+go 1.15
+
+require (
+	github.com/stretchr/testify v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -4,13 +4,9 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
-go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
+go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Currently the error struct doesn't adhere to Go's recommend error wrapping standards.

Bonus points: I ran `go mod init` :)