### PR TITLE
Panic recovery for worker and odd Negative WaitGroup issue

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -11,6 +11,7 @@ type (
 		All() []error
 		ToError() error
 		IsEmpty() bool
+		append(err error)
 	}
 
 	// errs is a thread safe struct for appending a slice of errors.

--- a/pool_test.go
+++ b/pool_test.go
@@ -104,27 +104,6 @@ func TestDispatcherCleanup(t *testing.T) {
 	assert.Equal(t, ngr, runtime.NumGoroutine())
 }
 
-type PanicJob struct{}
-
-func (e PanicJob) Execute() (Result, error) {
-	panic("wide spread panic test")
-	return nil, nil
-}
-
-func TestPanicJob(t *testing.T) {
-
-	d, e := NewDispatcher(1, 1)
-	if e != nil {
-		t.Fail()
-	}
-	d.Run()
-	d.Enqueue(PanicJob{}, PanicJob{}, PanicJob{})
-
-	results, errors := d.Wait()
-	assert.Equal(t, 3, len(results))
-	assert.Equal(t, 3, len(errors.All()))
-}
-
 // Benchmarks
 func benchmarkEchoJob(w, q int, b *testing.B) {
 	d, e := NewDispatcher(w, q)

--- a/pool_test.go
+++ b/pool_test.go
@@ -104,6 +104,27 @@ func TestDispatcherCleanup(t *testing.T) {
 	assert.Equal(t, ngr, runtime.NumGoroutine())
 }
 
+type PanicJob struct{}
+
+func (e PanicJob) Execute() (Result, error) {
+	panic("wide spread panic test")
+	return nil, nil
+}
+
+func TestPanicJob(t *testing.T) {
+
+	d, e := NewDispatcher(1, 1)
+	if e != nil {
+		t.Fail()
+	}
+	d.Run()
+	d.Enqueue(PanicJob{}, PanicJob{}, PanicJob{})
+
+	results, errors := d.Wait()
+	assert.Equal(t, 3, len(results))
+	assert.Equal(t, 3, len(errors.All()))
+}
+
 // Benchmarks
 func benchmarkEchoJob(w, q int, b *testing.B) {
 	d, e := NewDispatcher(w, q)

--- a/worker.go
+++ b/worker.go
@@ -1,5 +1,11 @@
 package bigopool
 
+import (
+	"fmt"
+	"runtime/debug"
+	"sync"
+)
+
 type (
 	Worker struct {
 		// A channel for receiving a job that was dispatched
@@ -23,8 +29,18 @@ func NewWorker(jobCh chan Job, errCh chan error, resultCh chan Result) Worker {
 
 // Start method starts the run loop for the worker, listening for a quit channel in
 // case we need to stop it
-func (w Worker) Start() {
+func (w Worker) Start(wg *sync.WaitGroup) {
+	wg.Add(1)
 	go func() {
+		defer func() {
+			// we probably don't want this because this will essentially hide panics that happen in
+			// the worker job.Execute() but with the WaitGroup negative error there will probably be a panic that happens on
+			// writing to a closed channel
+			if cause := recover(); cause != nil {
+				fmt.Println(string(debug.Stack()), cause)
+			}
+		}()
+		defer wg.Done()
 		for {
 			select {
 			case job, more := <-w.jobCh:

--- a/worker.go
+++ b/worker.go
@@ -1,10 +1,5 @@
 package bigopool
 
-import (
-	"errors"
-	"fmt"
-)
-
 type (
 	Worker struct {
 		// A channel for receiving a job that was dispatched
@@ -14,10 +9,6 @@ type (
 		errCh    chan error
 		resultCh chan Result
 	}
-)
-
-var (
-	errWorkerPanic = errors.New("worker panic")
 )
 
 // NewWorker creates a new worker that can be registered to a workerPool
@@ -34,14 +25,6 @@ func NewWorker(jobCh chan Job, errCh chan error, resultCh chan Result) Worker {
 // case we need to stop it
 func (w Worker) Start() {
 	go func() {
-		defer func() {
-			if cause := recover(); cause != nil {
-				w.errCh <- errors.New(fmt.Sprintf("%v", cause))
-				// send a panic error to notify we lost a worker
-				w.errCh <- errWorkerPanic
-				w.resultCh <- nil
-			}
-		}()
 		for {
 			select {
 			case job, more := <-w.jobCh:


### PR DESCRIPTION
We occasionally are seeing a very odd issue with a Negative WaitGroup panic when using the Dispatcher worker pool.

```
panic: sync: negative WaitGroup counter    
goroutine 7064575 [running]:  
sync.(*WaitGroup).Add(0xc00013e540, 0xffffffffffffffff)       
/.gimme/versions/go1.16.13.linux.amd64/src/sync/waitgroup.go:74 +0x147       
sync.(*WaitGroup).Done(...)       
/.gimme/versions/go1.16.13.linux.amd64/src/sync/waitgroup.go:99   
github.com/bigodines/bigopool.(*Dispatcher).Run.func1(0xc000404070)     
/gopath/pkg/mod/github.com/bigodines/bigopool@v3.2.0+incompatible/pool.go:105 +0x14d   
created by github.com/bigodines/bigopool.(*Dispatcher).Run      
/gopath/pkg/mod/github.com/bigodines/bigopool@v3.2.0+incompatible/pool.go:97 +0x75 
```
I have not figured out how to recreate it since it doesn't seem possible to call wg.Done prior to .Add or more than the amount of enqueued jobs. In the meantime I would like to add some recovery in the case that this happens so our service doesn't get killed.

Unfortunately, I'm not sure how to add a test for it since I don't know how to recreate having this [wg go negative](https://github.com/bigodines/bigopool/compare/master...waitstime:master#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R123). It's possibly not even a bug with bigopool at all.