### PR TITLE
add v3 to package name for go module compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bigodines/bigopool
+module github.com/bigodines/bigopool/v3
 
 go 1.15
 


### PR DESCRIPTION
Update go.mod version so `go get github.com/bigodines/bigopool` gets the latest release.

>go get github.com/bigodines/bigopool@v3.3.1
go: github.com/bigodines/bigopool@v3.3.1: invalid version: module contains a go.mod file, so module path must match major version ("github.com/bigodines/bigopool/v3")